### PR TITLE
running python3 setup.py resulted in the following error message that…

### DIFF
--- a/src/esm.c
+++ b/src/esm.c
@@ -262,11 +262,11 @@ PyInit_esm(void)
     PyObject* m;
 
     if (PyType_Ready(&esm_IndexType) < 0)
-        return;
+        return NULL;
 
     m = PyModule_Create(&esm_module);
     if (m == NULL) {
-        return;
+        return NULL;
     }
 
     Py_INCREF(&esm_IndexType);


### PR DESCRIPTION
… was fixed by adding NULL after return in lines 265 and 269:

src/esm.c:265:9: error: non-void function 'PyInit_esm' should return a value
      [-Wreturn-type]
        return;
        ^
src/esm.c:269:9: error: non-void function 'PyInit_esm' should return a value
      [-Wreturn-type]
        return;
        ^
2 errors generated.
error: command 'gcc' failed with exit status 1